### PR TITLE
Update JSCS rules

### DIFF
--- a/common/jscs.json
+++ b/common/jscs.json
@@ -110,5 +110,6 @@
   "requireLineFeedAtFileEnd": true,
   "maximumLineLength": 100,
   "requireCapitalizedConstructors": true,
-  "requireDotNotation": true
+  "requireDotNotation": true,
+  "disallowSpacesInsideParentheses": true
 }


### PR DESCRIPTION
Now forbid to use extraneous spaces inside parenthesis, for example:

```
// valid
if (true) {}
// invalid
if ( true ) {}
```
